### PR TITLE
Bump JS version

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ Deze versie op donderdag 18 februari 2016 online
   	<script src="api/jquery-1.11.2.min.js" type="text/javascript"></script>
 	<script src="api/OpenLayers.js" type="text/javascript"></script>
 	<script src="api/OpenStreetMap.js" type="text/javascript"></script>
-	<script src="http://maps.google.com/maps/api/js?v=3.2&amp;sensor=false" type="text/javascript"></script>
+	<script src="http://maps.google.com/maps/api/js?v=3.30" type="text/javascript"></script>
 	<script src="js_source/opm-min.js" type="text/javascript"></script>
 <!-- 
 	<script src="js_source/opm.js" type="text/javascript"></script>


### PR DESCRIPTION
All version <3.30 are deprecated https://developers.google.com/maps/documentation/javascript/versions

Fixes a google api error

@marczoutendijk I think there is nevertheless something wrong: E.g. searching for "parking" in berlin does not show any results (and there is also no corresponding error in the browser console)