### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/api/OpenStreetMap.js
+++ b/api/OpenStreetMap.js
@@ -14,9 +14,7 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
      */
     initialize: function(name, options) {
         var url = [
-            "https://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "https://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "https://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+            "https://tile.openstreetmap.org/${z}/${x}/${y}.png"
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 20,


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737

cc: @marczoutendijk 